### PR TITLE
MPEG-H Encoder fix #14

### DIFF
--- a/test/impeghe_mp4_writer.c
+++ b/test/impeghe_mp4_writer.c
@@ -1056,9 +1056,8 @@ static WORD32 impeghe_mp4_write_btrt(ia_mp4_writer_struct *pstr_mp4_writer_io, W
   WORD32 max_frame_data_size = pstr_mp4_writer_io->max_frame_data_size;
   WORD32 total_frame_data_size = pstr_mp4_writer_io->total_frame_data_size;
   WORD32 frame_count = pstr_mp4_writer_io->frame_count;
-  WORD32 avg_frame_data_size = total_frame_data_size / frame_count;
+  WORD32 avg_frame_data_size = (frame_count != 0) ? total_frame_data_size / frame_count: 0;
   WORD32 sample_rate = pstr_mp4_writer_io->sampling_freq;
-  WORD32 frame_lrngth = 1024;
   WORD32 max_bitrate = ((WORD32)(max_frame_data_size / (1024.0 / sample_rate))) << 3;
   WORD32 avg_bitrate = ((WORD32)(avg_frame_data_size / (1024.0 / sample_rate)) << 3);
   // box size

--- a/test/impeghe_testbench.c
+++ b/test/impeghe_testbench.c
@@ -2287,6 +2287,15 @@ clean_return:
     }
 
     // for mhm1 - mhas hdr added to 1st frame
+
+    for (int idx = 0; idx < frame_count; idx++)
+    {
+      mp4_writer_io.max_frame_data_size = mp4_writer_io.meta_info.ia_mp4_stsz_size[idx] > mp4_writer_io.max_frame_data_size ?
+        mp4_writer_io.meta_info.ia_mp4_stsz_size[idx] : mp4_writer_io.max_frame_data_size;
+      mp4_writer_io.total_frame_data_size += mp4_writer_io.meta_info.ia_mp4_stsz_size[idx];
+    }
+    mp4_writer_io.frame_count = frame_count;
+    mp4_writer_io.sampling_freq = pstr_in_cfg->aud_ch_pcm_cfg.sample_rate;
     if (op_fmt == MP4_MHM1)
     {
       ia_stsz_size[0] += pstr_out_cfg->i_dec_len;


### PR DESCRIPTION
Significance
------------
- Fix for division by zero in btrt box
- Fix for unintialized variable in btrt box with MPEG-H encoder testbench

Testing
-------
- Tested for encoder runtime fix