### PR TITLE
Encode OAM input with only static objects (channels) #23

### DIFF
--- a/encoder/impeghe_api.c
+++ b/encoder/impeghe_api.c
@@ -109,9 +109,13 @@ IA_ERRORCODE impeghe_process(ia_mpeghe_api_struct *p_obj_mpeghe, WORD32 *header_
  */
 static VOID impeghe_check_config_params(ia_input_config *pstr_input_config)
 {
-  WORD32 num_groups = pstr_input_config->num_obj_sig_groups +
-                      pstr_input_config->num_hoa_sig_groups +
+  WORD32 num_groups = pstr_input_config->num_hoa_sig_groups +
                       pstr_input_config->num_ch_sig_groups;
+  for (WORD32 i = 0; i < pstr_input_config->num_obj_sig_groups; i++)
+  {
+    if (pstr_input_config->use_oam_element[i])
+      num_groups++;
+  }
   for (WORD32 i = 0; i< num_groups; i++)
   {
     if (pstr_input_config->aud_ch_pcm_cfg[i].n_channels > 0)
@@ -389,11 +393,17 @@ static IA_ERRORCODE impeghe_set_config_params(ia_mpeghe_api_struct *p_obj_mpeghe
   LOOPIDX idx;
   LOOPIDX i, j;
   ia_usac_audio_specific_config_struct *pstr_asc = &p_obj_mpeghe->config.audio_specific_config;
-  WORD32 num_groups = pstr_input_config->num_obj_sig_groups +
-                      pstr_input_config->num_hoa_sig_groups +
+  WORD32 num_groups = pstr_input_config->num_hoa_sig_groups +
                       pstr_input_config->num_ch_sig_groups;
+
   WORD32 num_core_chn = 0;
   WORD32 num_st_objs = 0; // includes channels from channel based input and objects as well.
+
+  for (WORD32 i = 0; i < pstr_input_config->num_obj_sig_groups; i++)
+  {
+    if (pstr_input_config->use_oam_element[i])
+      num_groups++;
+  }
 
   for (i = 0; i < pstr_input_config->num_ch_sig_groups; i++)
   {
@@ -453,11 +463,11 @@ static IA_ERRORCODE impeghe_set_config_params(ia_mpeghe_api_struct *p_obj_mpeghe
   for (idx = 0; idx < pstr_input_config->num_obj_sig_groups; idx++)
   {
     if (OAM_MAX_NUM_OBJECTS < p_obj_mpeghe->config.num_objects[idx])
-  {
+    {
       p_obj_mpeghe->config.extra_objects[idx] = p_obj_mpeghe->config.num_objects[idx] - OAM_MAX_NUM_OBJECTS;
       p_obj_mpeghe->config.num_objects[idx] = OAM_MAX_NUM_OBJECTS;
-    error = IMPEGHE_CONFIG_NONFATAL_NUM_OBJECTS_UNSUPPORTED;
-  }
+      error = IMPEGHE_CONFIG_NONFATAL_NUM_OBJECTS_UNSUPPORTED;
+    }
 
 
     if (OAM_MAX_NUM_OBJECTS < p_obj_mpeghe->config.num_objects[idx])
@@ -629,7 +639,7 @@ static IA_ERRORCODE impeghe_set_config_params(ia_mpeghe_api_struct *p_obj_mpeghe
   // OAM Params
   memcpy(p_obj_mpeghe->config.use_oam_element, pstr_input_config->use_oam_element, sizeof(pstr_input_config->use_oam_element));
   p_obj_mpeghe->config.cicp_index = pstr_input_config->cicp_index;
-  if (pstr_input_config->use_oam_element[0])
+  if (p_obj_mpeghe->config.num_oam_ch)
   {
     // If OAM is in use, then ifile option is not valid
     if (pstr_input_config->use_hoa_element)
@@ -1149,7 +1159,7 @@ static IA_ERRORCODE impeghe_set_config_params(ia_mpeghe_api_struct *p_obj_mpeghe
         pstr_input_config->aud_ch_pcm_cfg[0].n_channels;
     pstr_input_config->str_drc_cfg.str_enc_params.sample_rate =
         pstr_input_config->aud_ch_pcm_cfg[0].sample_rate;
-    if (pstr_input_config->use_oam_element[0])
+    if (p_obj_mpeghe->config.num_oam_ch)
     {
       pstr_input_config->str_drc_cfg.str_uni_drc_config.str_channel_layout.base_ch_count +=
           pstr_input_config->num_oam_ch[0];
@@ -1213,7 +1223,7 @@ static IA_ERRORCODE impeghe_set_config_params(ia_mpeghe_api_struct *p_obj_mpeghe
     p_obj_mpeghe->config.str_ext_cfg_downmix_input = pstr_input_config->str_ext_cfg_downmix_input;
   }
 
-  if ((pstr_input_config->use_oam_element[0]) || (pstr_input_config->use_hoa_element))
+  if ((p_obj_mpeghe->config.num_oam_ch) || (pstr_input_config->use_hoa_element))
   {
     p_obj_mpeghe->config.basic_bitrate =
         p_obj_mpeghe->config.aud_ch * MINIMUM_BITRATE_PER_CHANNEL;
@@ -1742,10 +1752,14 @@ IA_ERRORCODE impeghe_create(pVOID pv_input, pVOID pv_output)
     pstr_input_config->codec_mode = USAC_ONLY_FD;
   }
 
-  if (1 == pstr_input_config->use_oam_element[0])
+  for (WORD32 i = 0; i < pstr_input_config->num_obj_sig_groups; i++)
   {
-    // OAM is always in FD mode.
-    pstr_input_config->codec_mode = USAC_ONLY_FD;
+    if (1 == pstr_input_config->use_oam_element[i])
+    {
+      // OAM is always in FD mode.
+      pstr_input_config->codec_mode = USAC_ONLY_FD;
+      break;
+    }
   }
 
   /*Error*/

--- a/encoder/impeghe_asc_write.c
+++ b/encoder/impeghe_asc_write.c
@@ -733,6 +733,11 @@ WORD32 impeghe_get_audiospecific_config_bytes(
 
       break;
     case 1:
+      while (pstr_audio_specific_config->num_objs_per_sig_group[obj_idx] == 0 &&
+             obj_idx < pstr_audio_specific_config->num_obj_sig_groups)
+      {
+        obj_idx++;
+      }
       bit_cnt += impeghe_write_escape_value(
           it_bit_buff, pstr_audio_specific_config->num_objs_per_sig_group[obj_idx++] - 1, 5, 8,
           16);

--- a/encoder/impeghe_enc_main.c
+++ b/encoder/impeghe_enc_main.c
@@ -892,7 +892,7 @@ IA_ERRORCODE impeghe_add_mct_ext_element(ia_usac_encoder_config_struct *pstr_usa
       {
         pstr_usac_data->mct_data[grp].num_channels = pstr_asc->num_objs_per_sig_group[grp];
       }
-      else if (grp == pstr_asc->num_ch_sig_groups + pstr_asc->num_obj_sig_groups)
+      else if (grp == pstr_asc->num_sig_grps - pstr_asc->num_hoa_sig_groups)
       {
         pstr_usac_data->mct_data[grp].num_channels = pstr_asc->num_hoas_per_sig_group[grp];
       }
@@ -978,7 +978,7 @@ IA_ERRORCODE impeghe_add_mct_ext_element(ia_usac_encoder_config_struct *pstr_usa
  */
 IA_ERRORCODE impeghe_add_oam_ext_element(ia_usac_encoder_config_struct *pstr_usac_config,
                                ia_usac_enc_state_struct *pstr_usac_state,
-                               WORD32 sig_idx)
+                               WORD32 sig_idx, WORD32 oam_ele_idx)
 {
   IA_ERRORCODE err_code;
   WORD32 idx;
@@ -1010,7 +1010,7 @@ IA_ERRORCODE impeghe_add_oam_ext_element(ia_usac_encoder_config_struct *pstr_usa
 #endif
   pstr_oam_config.extra_objects = pstr_usac_config->extra_objects[sig_idx];
 
-  err_code = impeghe_obj_md_enc_init(&pstr_usac_data->str_oam_state[sig_idx], &pstr_oam_config);
+  err_code = impeghe_obj_md_enc_init(&pstr_usac_data->str_oam_state[oam_ele_idx], &pstr_oam_config);
   if (err_code & IA_FATAL_ERROR)
   {
     return err_code;
@@ -1025,7 +1025,7 @@ IA_ERRORCODE impeghe_add_oam_ext_element(ia_usac_encoder_config_struct *pstr_usa
   pstr_usac_elem_config->oam_has_core_length = pstr_usac_config->oam_has_core_length[sig_idx];
   if (pstr_usac_config->oam_high_rate != 0)
   {
-    pstr_usac_elem_config->oam_block_size = pstr_usac_data->str_oam_state[sig_idx].oam_block_size;
+    pstr_usac_elem_config->oam_block_size = pstr_usac_data->str_oam_state[oam_ele_idx].oam_block_size;
   }
   else
   {
@@ -1033,19 +1033,19 @@ IA_ERRORCODE impeghe_add_oam_ext_element(ia_usac_encoder_config_struct *pstr_usa
   }
   
   pstr_usac_elem_config->oam_has_scrn_rel_objs = pstr_usac_config->oam_has_scrn_rel_objs[sig_idx];
-  pstr_usac_elem_config->oam_num_objects = pstr_usac_data->str_oam_state[sig_idx].str_config.num_objects;
+  pstr_usac_elem_config->oam_num_objects = pstr_usac_data->str_oam_state[oam_ele_idx].str_config.num_objects;
   for (idx = 0; idx < pstr_usac_elem_config->oam_num_objects; idx++)
   {
     pstr_usac_elem_config->oam_is_scrn_rel_obj[idx] =
         pstr_usac_config->oam_is_scrn_rel_obj[idx];
   }
   pstr_usac_elem_config->oam_has_dyn_obj_priority =
-      pstr_usac_data->str_oam_state[sig_idx].str_config.has_dyn_obj_priority;
+      pstr_usac_data->str_oam_state[oam_ele_idx].str_config.has_dyn_obj_priority;
   pstr_usac_elem_config->oam_has_uniform_spread =
-      pstr_usac_data->str_oam_state[sig_idx].str_config.has_uniform_spread;
+      pstr_usac_data->str_oam_state[oam_ele_idx].str_config.has_uniform_spread;
   
-  pstr_asc->num_audio_objs = pstr_usac_data->str_oam_state[sig_idx].str_config.num_objects;
-  //pstr_asc->num_audio_chs = pstr_usac_data->str_oam_state[sig_idx].str_config.num_channels;
+  pstr_asc->num_audio_objs = pstr_usac_data->str_oam_state[oam_ele_idx].str_config.num_objects;
+  //pstr_asc->num_audio_chs = pstr_usac_data->str_oam_state[oam_ele_idx].str_config.num_channels;
   
   pstr_asc_usac_config->num_elements++;
   pstr_asc_usac_config->num_ext_elements++;
@@ -1127,7 +1127,13 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
   }
 
   pstr_asc->num_sig_grps =
-      pstr_asc->num_ch_sig_groups + pstr_asc->num_obj_sig_groups + pstr_asc->num_hoa_sig_groups;
+      pstr_asc->num_ch_sig_groups + pstr_asc->num_hoa_sig_groups;
+
+  for (WORD32 i = 0; i < pstr_asc->num_obj_sig_groups; i++)
+  {
+    if (pstr_usac_config->use_oam_element[i])
+      pstr_asc->num_sig_grps++;
+  }
 
   if (pstr_asc->num_hoa_sig_groups > 1)
   {
@@ -1164,7 +1170,7 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
     }
     pstr_asc->channel_configuration = channel_config;
 
-    for (; g < pstr_asc->num_ch_sig_groups + pstr_asc->num_obj_sig_groups; g++)
+    for (; g < (pstr_asc->num_sig_grps - pstr_asc->num_hoa_sig_groups); g++)
     {
 
       pstr_asc->channel_configuration_grp[g] = 6; // Default value
@@ -1381,11 +1387,12 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
   obj_ele_start = pstr_asc_usac_config->num_elements;
   if (pstr_asc->num_obj_sig_groups > 0)
   {
+    WORD32 active_oam_ele = 0;
     for (j = 0; j < pstr_asc->num_obj_sig_groups; j++)
     {
       if (pstr_usac_config->use_oam_element[j] == 1)
       {
-        IA_ERRORCODE err_code = impeghe_add_oam_ext_element(pstr_usac_config, pstr_usac_state, j);
+        IA_ERRORCODE err_code = impeghe_add_oam_ext_element(pstr_usac_config, pstr_usac_state, j, active_oam_ele);
         if (err_code)
         {
           return err_code;
@@ -1399,6 +1406,7 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
           i++;
           ch_offset_idx++;
         }
+        active_oam_ele++;
       }
     }
   }
@@ -1574,7 +1582,7 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
     }
   }
 
-  if (1 == pstr_usac_config->use_oam_element[0])
+  if (pstr_usac_config->num_oam_elements > 0)
   {
     for (; el_id < tc_ele_start; el_id++)
     {
@@ -1584,6 +1592,9 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
         pstr_usac_data->str_qc_main.str_qc_data[i_ch].num_ch = 1;
         pstr_usac_data->str_qc_main.str_qc_data[i_ch].ch_bitrate =
             pstr_usac_config->oam_bitrate / pstr_usac_config->num_oam_ch;
+        pstr_usac_data->str_qc_main.str_qc_data[i_ch].avg_bits =
+            (pstr_usac_data->str_qc_main.str_qc_data[i_ch].ch_bitrate * FRAME_LEN_LONG) /
+            pstr_usac_config->sampling_rate;
         i_ch++;
       }
       else if (ID_USAC_CPE ==
@@ -1593,11 +1604,11 @@ IA_ERRORCODE impeghe_enc_init(ia_usac_encoder_config_struct *pstr_usac_config,
         pstr_usac_data->str_qc_main.str_qc_data[i_ch].num_ch = 2;
         pstr_usac_data->str_qc_main.str_qc_data[i_ch].ch_bitrate =
             2 * pstr_usac_config->oam_bitrate / pstr_usac_config->num_oam_ch;
+        pstr_usac_data->str_qc_main.str_qc_data[i_ch].avg_bits =
+            (pstr_usac_data->str_qc_main.str_qc_data[i_ch].ch_bitrate * FRAME_LEN_LONG) /
+            pstr_usac_config->sampling_rate;
         i_ch++;
       }
-      pstr_usac_data->str_qc_main.str_qc_data[i_ch].avg_bits =
-          (pstr_usac_data->str_qc_main.str_qc_data[i_ch].ch_bitrate * FRAME_LEN_LONG) /
-          pstr_usac_config->sampling_rate;
     }
   }
 

--- a/encoder/impeghe_fd_quant.c
+++ b/encoder/impeghe_fd_quant.c
@@ -351,21 +351,24 @@ static WORD32 impeghe_count_static_bits(ia_usac_data_struct *ptr_usac_data,
     stat_bits += (ptr_usac_data->mct_data_bit_cnt * channels) / (ptr_usac_config->channels - 1);
   }
 
-  if (ptr_usac_config->use_oam_element[0])
+  for (WORD32 o = 0; o <ptr_usac_config->num_obj_sig_groups; o++)
   {
+    if (ptr_usac_config->use_oam_element[o])
+    {
 #if 0
-    stat_bits += (ptr_usac_data->oam_data_bit_cnt) / (ptr_usac_config->channels);
+      stat_bits += (ptr_usac_data->oam_data_bit_cnt) / (ptr_usac_config->channels);
 #else
-    WORD32 num_objs = 0;
-    for(i = 0; i < ptr_usac_data->obj_ele_idx; i++)
-    {
-      num_objs += ptr_usac_config->num_objects[i];
-    }
-    if (num_objs)
-    {
-      stat_bits += ptr_usac_data->oam_data_bit_cnt / num_objs;
-    }
+      WORD32 num_objs = 0;
+      for(i = 0; i < ptr_usac_data->obj_ele_idx; i++)
+      {
+        num_objs += ptr_usac_config->num_objects[i];
+      }
+      if (num_objs)
+      {
+        stat_bits += ptr_usac_data->oam_data_bit_cnt / num_objs;
+      }
 #endif
+    }
   }
 
   return stat_bits;

--- a/test/impeghe_testbench.c
+++ b/test/impeghe_testbench.c
@@ -99,6 +99,7 @@ typedef enum impeghe_op_fmts
 
 FILE *g_pf_inp[56], *g_pf_out, *g_pf_spk, *g_asi, *g_loudness, *g_audio_truncate;
 FILE *g_pf_ec; // earcon inputfile
+WORD32 g_ch_in_file_idx[56], g_oam_in_file_idx[56];
 WORD8 ec_present = 0;
 WORD32 array_ec[1024] = {0};
 WORD8 pb_oam_file_path[IA_MAX_CMD_LINE_LENGTH] = "";
@@ -107,6 +108,7 @@ WORD8 pb_drc_file_path[IA_MAX_CMD_LINE_LENGTH] = "";
 impeghe_op_fmts op_fmt = RAW_MHAS;
 WORD32 use_drc_element = 0;
 WORD32 g_num_ifiles = 0, g_num_oamfiles = 0, g_num_hoafiles = 0;
+WORD32 g_num_ch_in_files, g_num_oam_in_files;
 
 pVOID g_ops_buf[32768];
 
@@ -1047,6 +1049,8 @@ static IA_ERRORCODE impeghe_read_oam_header(FILE *oam_file, ia_input_config *ptr
     strncat((char *)oam_file_path, (char *)item_name_buf,
             strnlen((const char *)item_name_buf, 64));
     g_pf_inp[g_num_ifiles] = fopen((const char *)oam_file_path, "rb");
+    g_ch_in_file_idx[g_num_ch_in_files] = g_num_ifiles;
+    g_num_ch_in_files++;
     if (NULL == g_pf_inp[g_num_ifiles])
     {
       printf("channel input file open failed\n");
@@ -1086,6 +1090,8 @@ static IA_ERRORCODE impeghe_read_oam_header(FILE *oam_file, ia_input_config *ptr
     strncat((char *)oam_file_path, (char *)item_name_buf,
             strnlen((const char *)item_name_buf, 64));
     g_pf_inp[g_num_ifiles] = fopen((const char *)oam_file_path, "rb");
+    g_oam_in_file_idx[g_num_oam_in_files] = g_num_ifiles;
+    g_num_oam_in_files++;
     if (NULL == g_pf_inp[g_num_ifiles])
     {
       fseek(oam_file, -OAM_OBJ_DESCRIPTION_SIZE_BYTES, SEEK_CUR);
@@ -1115,8 +1121,8 @@ static IA_ERRORCODE impeghe_read_oam_header(FILE *oam_file, ia_input_config *ptr
   if (ptr_in_cfg->num_objects[obj_sgi] > 0)
   {
     ptr_in_cfg->use_oam_element[obj_sgi] = 1;
-    ptr_in_cfg->num_obj_sig_groups++;
   }
+  ptr_in_cfg->num_obj_sig_groups++;
 
   *num_channels_to_encode = ptr_in_cfg->num_ch_per_sig_grp[ch_grp_idx] + ptr_in_cfg->num_objects[obj_sgi];
 
@@ -2186,6 +2192,7 @@ IA_ERRORCODE impeghe_main_process(WORD32 argc, pWORD8 argv[])
   i_bytes_read = 0; write_offset = 0;
   for (WORD32 ii = 0; ii < pstr_out_cfg->in_frame_length; ii++)
   {
+#if 0
     for (WORD32 jj = 0; jj < g_num_ifiles; jj++)
     {
       if (g_pf_inp[jj])
@@ -2205,6 +2212,48 @@ IA_ERRORCODE impeghe_main_process(WORD32 argc, pWORD8 argv[])
         write_offset += bytes_to_read;
       }
     }
+#else
+    for (WORD32 jj = 0; jj < g_num_ch_in_files; jj++)
+    {
+      WORD32 idx = g_ch_in_file_idx[jj];
+      if (g_pf_inp[idx])
+      {
+        WORD32 pcm_wd_size = (pstr_in_cfg->aud_ch_pcm_cfg[idx].pcm_sz >> 3);
+        WORD32 f_channels = (pstr_in_cfg->aud_ch_pcm_cfg[idx].n_channels);
+        WORD32 bytes_to_read = f_channels * pcm_wd_size;
+        WORD32 ret_val = impeghe_fread((pVOID)&pb_inp_buf[write_offset],
+                                     sizeof(WORD8),
+                                     bytes_to_read,
+                                     g_pf_inp[idx]);
+        i_bytes_read += ret_val;
+        if (ret_val != bytes_to_read)
+        {
+          memset(&pb_inp_buf[i_bytes_read], 0, bytes_to_read - ret_val);
+        }
+        write_offset += bytes_to_read;
+      }
+    }
+    for (WORD32 jj = 0; jj < g_num_oam_in_files; jj++)
+    {
+      WORD32 idx = g_oam_in_file_idx[jj];
+      if (g_pf_inp[idx])
+      {
+        WORD32 pcm_wd_size = (pstr_in_cfg->aud_ch_pcm_cfg[idx].pcm_sz >> 3);
+        WORD32 f_channels = (pstr_in_cfg->aud_ch_pcm_cfg[idx].n_channels);
+        WORD32 bytes_to_read = f_channels * pcm_wd_size;
+        WORD32 ret_val = impeghe_fread((pVOID)&pb_inp_buf[write_offset],
+                                     sizeof(WORD8),
+                                     bytes_to_read,
+                                     g_pf_inp[idx]);
+        i_bytes_read += ret_val;
+        if (ret_val != bytes_to_read)
+        {
+          memset(&pb_inp_buf[i_bytes_read], 0, bytes_to_read - ret_val);
+        }
+        write_offset += bytes_to_read;
+      }
+    }
+#endif
   }
 
   if (g_is_hoa_input)
@@ -2353,14 +2402,17 @@ clean_return:
     g_pf_ec = NULL;
   }
 
-  if (pstr_in_cfg->use_oam_element[0] == 1)
+  for (WORD32 o = 0; o < pstr_in_cfg->num_obj_sig_groups; o++)
   {
-    for (i = 0; i < num_channels_to_encode; i++)
+    if (pstr_in_cfg->use_oam_element[o] == 1)
     {
-      if (g_pf_inp[i])
+      for (i = 0; i < num_channels_to_encode; i++)
       {
-        fclose(g_pf_inp[i]);
-        g_pf_inp[i] = NULL;
+        if (g_pf_inp[i])
+        {
+          fclose(g_pf_inp[i]);
+          g_pf_inp[i] = NULL;
+        }
       }
     }
   }
@@ -2496,6 +2548,10 @@ WORD32 main(WORD32 argc, char *argv[])
       g_num_ifiles = 0;
       g_num_oamfiles = 0;
       g_num_hoafiles = 0;
+      g_num_ch_in_files = 0;
+      g_num_oam_in_files = 0;
+      memset(g_ch_in_file_idx, 0 , sizeof(g_ch_in_file_idx));
+      memset(g_oam_in_file_idx, 0 , sizeof(g_oam_in_file_idx));
       memset(pb_oam_file_name, 0, sizeof(pb_oam_file_name));
       curpos = 0;
       fargc = 0;
@@ -2609,6 +2665,8 @@ WORD32 main(WORD32 argc, char *argv[])
                 err_code = IA_TESTBENCH_MFMAN_FATAL_FILE_OPEN_FAILED;
                 impeghe_error_handler(&ia_testbench_error_info, (pWORD8) "Input File", err_code);
               }
+              g_ch_in_file_idx[g_num_ch_in_files] = g_num_ifiles;
+              g_num_ch_in_files++;
               file_count++;
               f++; g_num_ifiles++;
               p_file_name = (pWORD8)strtok(NULL, p_separator);
@@ -2834,6 +2892,10 @@ WORD32 main(WORD32 argc, char *argv[])
     WORD8 pb_output_file_name[IA_MAX_CMD_LINE_LENGTH] = "";
     WORD32 file_count = 0;
     g_num_ifiles = 0;
+    g_num_ch_in_files = 0;
+    g_num_oam_in_files = 0;
+    memset(g_ch_in_file_idx, 0 , sizeof(g_ch_in_file_idx));
+    memset(g_oam_in_file_idx, 0 , sizeof(g_oam_in_file_idx));
     for (i = 1; i < argc; i++)
     {
       printf("%s ", argv[i]);
@@ -2857,6 +2919,8 @@ WORD32 main(WORD32 argc, char *argv[])
             err_code = IA_TESTBENCH_MFMAN_FATAL_FILE_OPEN_FAILED;
             impeghe_error_handler(&ia_testbench_error_info, (pWORD8) "Input File", err_code);
           }
+          g_ch_in_file_idx[g_num_ch_in_files] = g_num_ifiles;
+          g_num_ch_in_files++;
           file_count++;
           f++; g_num_ifiles++;
           p_file_name = (pWORD8)strtok((char *)NULL, p_separator);


### PR DESCRIPTION
Significance:
-------------
- Support to encode OAM files with only object input.
- Addresses the crash issue reported in #23

Testing:
--------
- Smoke testing with previous commit.